### PR TITLE
Avoid repeated shrinks of wizard div due to errors in original HTML of the extension

### DIFF
--- a/ckanext/wirecloud_view/fanstatic/wirecloud_option.js
+++ b/ckanext/wirecloud_view/fanstatic/wirecloud_option.js
@@ -10,7 +10,7 @@ ckan.module('wirecloud_option', function ($, _) {
 
 			for (var elem = 0; elem < elems.length; elem++){
 				elems[elem].onclick = function () {
-                    $("graph_editor_div").toggle("fast");
+                    $("#graph_editor_div").toggle("fast");
 				}
 			}
 

--- a/ckanext/wirecloud_view/fanstatic/wirecloud_option.js
+++ b/ckanext/wirecloud_view/fanstatic/wirecloud_option.js
@@ -10,12 +10,7 @@ ckan.module('wirecloud_option', function ($, _) {
 
 			for (var elem = 0; elem < elems.length; elem++){
 				elems[elem].onclick = function () {
-
-					if (this.classList.contains("small")) {
-                        this.classList.remove("small");
-					} else {
-                        this.classList.add("small");
-                    }
+                    $("graph_editor_div").toggle("fast");
 				}
 			}
 
@@ -28,6 +23,8 @@ ckan.module('wirecloud_option', function ($, _) {
 
                 document.getElementById("field-dashboard").value = event.data;
 			    document.getElementsByClassName('option')[0].classList.add("small");
+                // Assure hidden at start
+                $("graph_editor_div").toggle(false);
             };
 
             window.addEventListener("message", receiveMessage, false);

--- a/ckanext/wirecloud_view/fanstatic/wirecloud_option.js
+++ b/ckanext/wirecloud_view/fanstatic/wirecloud_option.js
@@ -1,33 +1,32 @@
 "use strict";
 
 ckan.module('wirecloud_option', function ($, _) {
-	return {
-		initialize: function () {
+    return {
+        initialize: function () {
 
-			$.proxyAll(this, /_on/);
+            $.proxyAll(this, /_on/);
 
-			var elems = document.getElementsByClassName('option');
+            var elems = document.getElementsByClassName('option');
 
-			for (var elem = 0; elem < elems.length; elem++){
-				elems[elem].onclick = function () {
+            for (var elem = 0; elem < elems.length; elem++){
+                elems[elem].onclick = function () {
                     $("#graph_editor_div").toggle("fast");
-				}
-			}
+                }
+            }
+            // Assure hidden at start
+            $("#graph_editor_div").toggle(false);
 
             var receiveMessage = function receiveMessage(event) {
-                // For Chrome, the origin property is in the event.originalEvent object.
-                // var origin = event.origin || event.originalEvent.origin;
-                // if (origin !== "http://example.org:8080") {
-                //    return;
-                //}
-
-                document.getElementById("field-dashboard").value = event.data;
-			    document.getElementsByClassName('option')[0].classList.add("small");
-                // Assure hidden at start
-                $("graph_editor_div").toggle(false);
+                // Avoid multiple events coming from within CKAN server
+                var u = new URL(document.getElementById("graph_editor").src);
+                if (event.origin.startsWith(u.protocol + "//" + u.host)) {
+                    document.getElementById("field-dashboard").value = event.data;
+                    // Hide after creating dashboard
+                    $("#graph_editor_div").toggle(false);
+                }
             };
 
             window.addEventListener("message", receiveMessage, false);
-		}
-	};
+        }
+    };
 });

--- a/ckanext/wirecloud_view/templates/wirecloud_form.html
+++ b/ckanext/wirecloud_view/templates/wirecloud_form.html
@@ -9,6 +9,6 @@
 <div class="control-group form-group option small" data-module="wirecloud_option">
 	<span class="wc_sp">Create a new dashboard</span>
 </div>
-<div id="graph_editor_div" style="display:none;">
+<div id="graph_editor_div">
     <iframe id="graph_editor" style="margin:auto; height:900px;display:block; width:100%;" src="{{ h.get_editor_url() + '?mode=embedded&ckanserver=' + "://".join(h.get_site_protocol_and_host()) + '&resourceid=' + resource.get('id')}}" frameborder="0" allowfullscreen></iframe>
 </div>

--- a/ckanext/wirecloud_view/templates/wirecloud_form.html
+++ b/ckanext/wirecloud_view/templates/wirecloud_form.html
@@ -8,5 +8,7 @@
 
 <div class="control-group form-group option small" data-module="wirecloud_option">
 	<span class="wc_sp">Create a new dashboard</span>
-	<iframe id="graph_editor" style="margin:auto; height:900px;display:block; width:100%;" src="{{ h.get_editor_url() + '?mode=embedded&ckanserver=' + "://".join(h.get_site_protocol_and_host()) + '&resourceid=' + resource.get('id')}}" frameborder="0" allowfullscreen></iframe>
+</div>
+<div id="graph_editor_div" style="display:none;">
+    <iframe id="graph_editor" style="margin:auto; height:900px;display:block; width:100%;" src="{{ h.get_editor_url() + '?mode=embedded&ckanserver=' + "://".join(h.get_site_protocol_and_host()) + '&resourceid=' + resource.get('id')}}" frameborder="0" allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
The iframe was inside the extension DIV that acted as a button. As a consequence, every click on the wizard did fire a click event on the button and shrank the iframe, hiding it.